### PR TITLE
removed pprint used json.dump instead

### DIFF
--- a/src/datasets.py
+++ b/src/datasets.py
@@ -50,9 +50,8 @@ class GeonodeDatasetsHandler(GeonodeResourceHandler):
             **kwargs
         )
         if kwargs["json"] is True:
-            import pprint
+            self.print_json(r)
 
-            pprint.pprint(r)
         else:
             list_items = [
                 ["title", title],

--- a/src/documents.py
+++ b/src/documents.py
@@ -56,9 +56,8 @@ class GeonodeDocumentsHandler(GeonodeResourceHandler):
             ["download-url", r["href"]],
         ]
         if kwargs["json"]:
-            import pprint
+            self.print_json(r)
 
-            pprint.pprint(r)
         else:
             show_list(values=list_items, headers=["key", "value"])
 

--- a/src/geonodeobject.py
+++ b/src/geonodeobject.py
@@ -1,7 +1,5 @@
-from typing import List, Dict
-import pprint
+from typing import List, Dict, Union
 import json
-import logging
 
 from src.geonodetypes import GeonodeCmdOutObjectKey, GeonodeCmdOutListKey
 from src.rest import GeonodeRest
@@ -19,11 +17,15 @@ class GeonodeObjectHandler(GeonodeRest):
     RESOURCE_TYPE: str = ""
     SINGULAR_RESOURCE_NAME: str = ""
 
+    @classmethod
+    def print_json(cls, json_str: Union[str, dict]):
+        print(json.dumps(json_str, indent=2))
+
     def cmd_list(self, **kwargs):
         """show list of geonode obj on the cmdline"""
         obj = self.list(**kwargs)
         if kwargs["json"]:
-            pprint.pprint(obj)
+            self.print_json(obj)
         else:
             self.__class__.print_list_on_cmd(obj)
 
@@ -50,7 +52,7 @@ class GeonodeObjectHandler(GeonodeRest):
 
     def cmd_patch(self, pk: int, fields: str, **kwargs):
         obj = self.patch(pk, fields, **kwargs)
-        pprint.pprint(obj)
+        self.print_json(obj)
 
     def patch(self, pk: int, fields: str, **kwargs) -> Dict:
         """tries to generate  object from incoming json string
@@ -78,7 +80,7 @@ class GeonodeObjectHandler(GeonodeRest):
 
     def cmd_describe(self, pk: int, **kwargs):
         obj = self.get(pk=pk, **kwargs)
-        pprint.pprint(obj)
+        self.print_json(obj)
 
     def get(self, pk: int, **kwargs) -> Dict:
         """get details for a given pk

--- a/src/people.py
+++ b/src/people.py
@@ -1,5 +1,4 @@
 from typing import Dict
-import pprint
 
 from src.geonodeobject import GeonodeObjectHandler
 from src.resources import GeonodeResourceHandler
@@ -44,7 +43,7 @@ class GeonodePeopleHandler(GeonodeObjectHandler):
         if kwargs["user_resources"] is True:
             GeonodeResourceHandler.print_list_on_cmd(obj)
         else:
-            pprint.pprint(obj)
+            self.print_json(obj)
 
     def get(
         self, pk: int, user_resources: bool = False, user_groups: bool = False, **kwargs

--- a/src/rest.py
+++ b/src/rest.py
@@ -95,7 +95,6 @@ class GeonodeRest(object):
             r.raise_for_status()
         except requests.exceptions.HTTPError as err:
             raise SystemExit(err)
-
         return r.json()
 
     def http_patch(self, endpoint: str, params: Dict = {}) -> Dict:
@@ -119,7 +118,6 @@ class GeonodeRest(object):
             r.raise_for_status()
         except requests.exceptions.HTTPError as err:
             raise SystemExit(err)
-
         return r.json()
 
     def http_delete(self, endpoint: str, params: Dict = {}) -> Dict:


### PR DESCRIPTION
After patch, describe or using --json it's now possible to pipeline the result with cmdlinetool jq und filter out parts of the result like: 

closes #12 

```
❯ geonodectl ds patch 1 --set '{"category":{"identifier": "farming"}}' | jq '.dataset.category'
{
  "identifier": "farming"
}
```