### PR TITLE
[Fixes #81] Bug: set rasterdatasets as maplayer when creating a map fails

### DIFF
--- a/src/geonoderest/maps.py
+++ b/src/geonoderest/maps.py
@@ -14,6 +14,7 @@ from .geonodetypes import (
 )
 
 OGC_WFS_LINK_TYPE = "OGC:WFS"
+OGC_WCS_LINK_TYPE = "OGC:WCS"
 
 
 class GeonodeMapsHandler(GeonodeResourceHandler):
@@ -170,6 +171,8 @@ class GeonodeMapsHandler(GeonodeResourceHandler):
 
         for link in dataset["links"]:
             if link["link_type"] == OGC_WFS_LINK_TYPE:
+                wfs_url = link["url"]
+            if link["link_type"] == OGC_WCS_LINK_TYPE:
                 wfs_url = link["url"]
 
         ptype = "wms" if dataset["ptype"] == "gxp_wmscsource" else "wfs"


### PR DESCRIPTION
## Description

fixes bug that has thrown an exception when trying to add a raster dataset to a map using geonodectl maps create --maplayer ?

ref #81 
## Type of Change

Please select the relevant option:

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Release
- [ ] Other (please describe)

## Related Issue

If there is an existing issue related to this pull request, please reference it here.

closes #81

## Checklist

Please ensure that your pull request meets the following requirements:

- The pull request is limited to one type (docs, feature, bug fix, etc.)
- The pull request is as small as possible. Consider opening multiple pull requests instead of one large one.
- The feature or bug fix has been discussed and documented in an issue beforehand.

## Additional Notes

Any additional information or context regarding the pull request can be provided here.

Thank you for creating this pull request