### PR TITLE
[Fixes #121] Bug: type error crash when api filter returns no results none type has no len 

### DIFF
--- a/src/geonoderest/cmdprint.py
+++ b/src/geonoderest/cmdprint.py
@@ -33,6 +33,9 @@ def print_list_on_cmd(obj: Dict, cmdout_header: List[GeonodeCmdOutObjectKey]):
     Args:
         obj (Dict): dict object to print on cmd line
     """
+    if obj is None:
+        logging.warning("return from geonode api was broken, not output ...")
+        return
 
     def generate_line(i, obj: Dict, headers: List[GeonodeCmdOutObjectKey]) -> List:
         return [cmdoutkey.get_key(obj[i]) for cmdoutkey in headers]

--- a/src/geonoderest/geonodeobject.py
+++ b/src/geonoderest/geonodeobject.py
@@ -26,6 +26,9 @@ class GeonodeObjectHandler(GeonodeRest):
     def cmd_list(self, **kwargs):
         """show list of geonode obj on the cmdline"""
         obj = self.list(**kwargs)
+        if obj is None:
+            logging.warning("No results returned from GeoNode API.")
+            return
         if kwargs["json"]:
             print_json(obj)
         else:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,8 +1,7 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from geonoderest.datasets import GeonodeDatasetsHandler
-import unittest
-from unittest.mock import patch
+from geonoderest.cmdprint import print_list_on_cmd
 
 
 class TestGeonodeDatasetsHandler(unittest.TestCase):
@@ -57,6 +56,60 @@ class TestGeonodeDatasetHandler(unittest.TestCase):
         handler = GeonodeDatasetsHandler(env={})
         result = handler.patch(123, json_content={"title": "Updated"})
         self.assertTrue(result["success"])
+
+
+class TestCmdListNoneHandling(unittest.TestCase):
+    """Tests for graceful handling when API returns None (e.g. invalid filter or error response).
+    Regression test for: https://github.com/GeoNodeUserGroup-DE/geonodectl/issues/121
+    """
+
+    @patch.object(GeonodeDatasetsHandler, "list")
+    def test_cmd_list_does_not_crash_when_api_returns_none(self, mock_list):
+        """cmd_list must not raise TypeError when list() returns None."""
+        mock_list.return_value = None
+        handler = GeonodeDatasetsHandler(env={})
+        try:
+            handler.cmd_list(json=False, filter={"is_featured": "true"})
+        except TypeError as e:
+            self.fail(f"cmd_list raised TypeError unexpectedly: {e}")
+
+    @patch.object(GeonodeDatasetsHandler, "list")
+    def test_cmd_list_json_does_not_crash_when_api_returns_none(self, mock_list):
+        """cmd_list with --json flag must not crash when list() returns None."""
+        mock_list.return_value = None
+        handler = GeonodeDatasetsHandler(env={})
+        try:
+            handler.cmd_list(json=True, filter={"is_featured": "true"})
+        except TypeError as e:
+            self.fail(f"cmd_list raised TypeError unexpectedly: {e}")
+
+    def test_print_list_on_cmd_does_not_crash_on_none(self):
+        """print_list_on_cmd must not raise TypeError when obj is None."""
+        try:
+            print_list_on_cmd(None, [])
+        except TypeError as e:
+            self.fail(f"print_list_on_cmd raised TypeError unexpectedly: {e}")
+
+    @patch.object(GeonodeDatasetsHandler, "list")
+    def test_cmd_list_works_normally_with_valid_results(self, mock_list):
+        """cmd_list must still work correctly when list() returns valid data."""
+        mock_list.return_value = [
+            {
+                "pk": 1,
+                "title": "Test Dataset",
+                "owner": {"username": "admin"},
+                "date": "2026-01-01",
+                "is_approved": True,
+                "is_published": True,
+                "state": "PROCESSED",
+                "detail_url": "/datasets/1",
+            }
+        ]
+        handler = GeonodeDatasetsHandler(env={})
+        try:
+            handler.cmd_list(json=False, filter={})
+        except Exception as e:
+            self.fail(f"cmd_list raised unexpectedly: {e}")
 
 
 if __name__ == "__main__":

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,14 +1,9 @@
 import unittest
-<<<<<<< issue_#121_Bug__TypeError_crash_when_API_filter_returns_no_results__NoneType_has_no_len_
-from unittest.mock import patch, MagicMock
-from geonoderest.datasets import GeonodeDatasetsHandler
-from geonoderest.cmdprint import print_list_on_cmd
-=======
 
 from unittest.mock import patch, call, MagicMock
 from geonoderest.datasets import GeonodeDatasetsHandler
+from geonoderest.cmdprint import print_list_on_cmd
 from geonoderest.executionrequest import GeonodeExecutionRequestHandler
->>>>>>> main
 
 
 class TestGeonodeDatasetsHandler(unittest.TestCase):
@@ -224,6 +219,8 @@ class TestCmdDescribeRange(unittest.TestCase):
         handler.cmd_describe(pk="10,20,30")
         endpoints = [c.kwargs["endpoint"] for c in mock_http_get.call_args_list]
         self.assertEqual(endpoints, ["datasets/10", "datasets/20", "datasets/30"])
+
+
 class TestWaitForUpload(unittest.TestCase):
     """Tests for __wait_for_upload__ and cmd_upload --wait.
     Feature test for: https://github.com/GeoNodeUserGroup-DE/geonodectl/issues/80


### PR DESCRIPTION
## Description
Fixes a bug in geonodectl that throws an error when retrieving an empty list from geonode.

## Type of Change

Please select the relevant option:

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Release
- [ ] Other (please describe)

## Related Issue

If there is an existing issue related to this pull request, please reference it here.

closes #121
