### PR TITLE
Add userinfo, permissions, wms handlers and async-execution polling

### DIFF
--- a/src/geonoderest/datasets.py
+++ b/src/geonoderest/datasets.py
@@ -10,6 +10,7 @@ from geonoderest.geonodetypes import GeonodeHTTPFile
 from geonoderest.cmdprint import show_list, print_json
 from geonoderest.geonodetypes import GeonodeCmdOutListKey, GeonodeCmdOutDictKey
 from geonoderest.executionrequest import GeonodeExecutionRequestHandler
+from geonoderest.exceptions import GeoNodeRestException
 
 
 class GeonodeDatasetsHandler(GeonodeResourceHandler):
@@ -107,26 +108,18 @@ class GeonodeDatasetsHandler(GeonodeResourceHandler):
         execution_request_handler = GeonodeExecutionRequestHandler(
             env=self.gn_credentials
         )
-        elapsed = 0
-        while True:
-            er = execution_request_handler.get(exec_id=exec_id)
-            status = er.get("status", "")
-            if status in ("finished", "failed"):
-                break
-            logging.info(f"waiting for upload to finish ({elapsed}s) ...")
-            time.sleep(poll_interval)
-            elapsed += poll_interval
-
-        if er.get("status") == "failed":
-            logging.error("upload failed ...")
-            logging.error(er)
+        try:
+            er = execution_request_handler.wait_for_completion(
+                exec_id=exec_id, poll_interval=poll_interval
+            )
+        except GeoNodeRestException as exc:
+            logging.error(str(exc))
             sys.exit(1)
-
         logging.info("upload finished ...")
-        pks = []
-        for resource in er.get("output_params", {}).get("resources", []):
-            pks.append(resource["id"])
-        return pks
+        return [
+            resource["id"]
+            for resource in er.get("output_params", {}).get("resources", [])
+        ]
 
     def upload(
         self,

--- a/src/geonoderest/executionrequest.py
+++ b/src/geonoderest/executionrequest.py
@@ -1,10 +1,14 @@
 from typing import Dict, List, Optional
 import logging
+import time
 
 from geonoderest.geonodetypes import GeonodeCmdOutListKey, GeonodeCmdOutObjectKey
 from geonoderest.rest import GeonodeRest
+from geonoderest.exceptions import GeoNodeRestException
 
 from geonoderest.cmdprint import print_list_on_cmd, print_json
+
+TERMINAL_STATUSES = ("finished", "failed")
 
 
 class GeonodeExecutionRequestHandler(GeonodeRest):
@@ -63,3 +67,60 @@ class GeonodeExecutionRequestHandler(GeonodeRest):
         if r is None:
             return None
         return r[self.JSON_OBJECT_NAME]
+
+    def wait_for_completion(
+        self,
+        exec_id: str,
+        poll_interval: int = 2,
+        timeout: int = 600,
+        on_poll=None,
+    ) -> Dict:
+        """Poll an execution request until it reaches a terminal status.
+
+        Used by any async-acknowledged operation that returns an execution_id:
+        uploads, async resource deletes, permission changes, etc.
+
+        Args:
+            exec_id (str): Execution request UUID.
+            poll_interval (int): Seconds between polls. Defaults to 2.
+            timeout (int): Max seconds to wait before giving up. Defaults to 600.
+            on_poll (callable, optional): Invoked with the latest record after
+                each poll. Useful for surfacing progress to the user.
+
+        Returns:
+            Dict: The terminal execution record (status == "finished").
+
+        Raises:
+            GeoNodeRestException: If the execution reports `failed` or the
+                timeout elapses before reaching a terminal status.
+        """
+        elapsed = 0
+        last: Optional[Dict] = None
+        while elapsed <= timeout:
+            er = self.get(exec_id=exec_id)
+            if er is None:
+                raise GeoNodeRestException(
+                    f"execution {exec_id} not found while polling"
+                )
+            last = er
+            status = (er.get("status") or "").lower()
+            if on_poll is not None:
+                on_poll(er)
+            if status == "finished":
+                logging.info(f"execution {exec_id} finished in ~{elapsed}s")
+                return er
+            if status == "failed":
+                raise GeoNodeRestException(
+                    f"execution {exec_id} failed: "
+                    f"{er.get('log') or er.get('output_params')}"
+                )
+            logging.debug(
+                f"waiting for execution {exec_id} (status={status}, "
+                f"elapsed={elapsed}s) ..."
+            )
+            time.sleep(poll_interval)
+            elapsed += poll_interval
+        raise GeoNodeRestException(
+            f"execution {exec_id} did not reach a terminal status within "
+            f"{timeout}s (last status: {last.get('status') if last else 'unknown'})"
+        )

--- a/src/geonoderest/permissions.py
+++ b/src/geonoderest/permissions.py
@@ -1,0 +1,66 @@
+from typing import Dict, Optional
+
+from geonoderest.rest import GeonodeRest
+from geonoderest.executionrequest import GeonodeExecutionRequestHandler
+
+
+class GeonodePermissionsHandler(GeonodeRest):
+    """GET / PUT /api/v2/resources/{pk}/permissions.
+
+    The PUT endpoint is asynchronous: the response carries an
+    ``execution_id`` and ``status_url`` rather than the applied state.
+    Callers should invoke :meth:`wait_for_completion` (or poll the
+    ``execution_id`` themselves) before assuming the change is visible to
+    downstream readers.
+    """
+
+    def get(self, pk: int) -> Optional[Dict]:
+        """Return the current permission set for a resource.
+
+        Args:
+            pk (int): Resource primary key.
+
+        Returns:
+            Dict with keys ``users``, ``groups``, ``organizations``, each
+            holding a list of entries with id, name, and permission level,
+            or None on error.
+        """
+        return self.http_get(endpoint=f"resources/{pk}/permissions")
+
+    def set(self, pk: int, payload: Dict) -> Optional[Dict]:
+        """Submit a new permission set. Returns the async receipt.
+
+        The receipt has the shape::
+
+            {
+              "status": "ready",
+              "execution_id": "<uuid>",
+              "status_url": "<absolute url>"
+            }
+
+        Pass the ``execution_id`` to :meth:`wait_for_completion` to block
+        until the permission change has been applied.
+        """
+        return self.http_put(
+            endpoint=f"resources/{pk}/permissions", json_content=payload
+        )
+
+    def wait_for_completion(
+        self,
+        exec_id: str,
+        poll_interval: int = 2,
+        timeout: int = 120,
+        on_poll=None,
+    ) -> Dict:
+        """Poll an in-flight permission change until it reaches a terminal state.
+
+        Delegates to :class:`GeonodeExecutionRequestHandler` so the polling
+        behavior matches uploads and async deletes.
+        """
+        handler = GeonodeExecutionRequestHandler(env=self.gn_credentials)
+        return handler.wait_for_completion(
+            exec_id=exec_id,
+            poll_interval=poll_interval,
+            timeout=timeout,
+            on_poll=on_poll,
+        )

--- a/src/geonoderest/resources.py
+++ b/src/geonoderest/resources.py
@@ -1,10 +1,11 @@
-from typing import List
+from typing import List, Dict, Optional
 import requests
 import logging
 
 from geonoderest.geonodeobject import GeonodeObjectHandler
 from geonoderest.geonodetypes import GeonodeCmdOutListKey, GeonodeCmdOutDictKey
 from geonoderest.exceptions import GeoNodeRestException
+from geonoderest.executionrequest import GeonodeExecutionRequestHandler
 
 SUPPORTED_METADATA_TYPES: List[str] = [
     "Atom",
@@ -62,3 +63,35 @@ class GeonodeResourceHandler(GeonodeObjectHandler):
         link: str
         link = [m for m in r["links"] if m["name"] == metadata_type][0]["url"]
         return self.http_get_download(link)
+
+    def delete_async(self, pk: int) -> Optional[Dict]:
+        """Asynchronous delete via ``DELETE /api/v2/resources/{pk}/delete``.
+
+        Unlike :meth:`delete` (which hits the synchronous endpoint), this
+        returns an async receipt — ``{status, execution_id, status_url}`` —
+        suitable for passing to :meth:`wait_for_completion`. Use this when
+        the caller needs to confirm the deletion completed (e.g. before
+        relying on it in a downstream assertion).
+        """
+        return self.http_delete(endpoint=f"{self.ENDPOINT_NAME}/{pk}/delete")
+
+    def wait_for_completion(
+        self,
+        exec_id: str,
+        poll_interval: int = 2,
+        timeout: int = 180,
+        on_poll=None,
+    ) -> Dict:
+        """Poll an async resource operation (delete, copy, …) to completion.
+
+        Delegates to :class:`GeonodeExecutionRequestHandler` so the polling
+        behavior is consistent across uploads, deletes, and permission
+        changes.
+        """
+        handler = GeonodeExecutionRequestHandler(env=self.gn_credentials)
+        return handler.wait_for_completion(
+            exec_id=exec_id,
+            poll_interval=poll_interval,
+            timeout=timeout,
+            on_poll=on_poll,
+        )

--- a/src/geonoderest/rest.py
+++ b/src/geonoderest/rest.py
@@ -245,6 +245,72 @@ class GeonodeRest(object):
         return r.json()
 
     @network_exception_handling
+    def http_put(
+        self, endpoint: str, json_content: Dict = {}, params: Dict = {}, **kwargs
+    ) -> Optional[Dict]:
+        """
+        Execute HTTP PUT request on the specified endpoint with optional parameters.
+
+        Args:
+            endpoint (str): The API endpoint to send the PUT request to.
+            json_content (Dict, optional): A dictionary of JSON data to include in the request body.
+            params (Dict, optional): A dictionary of query parameters to include in the request.
+
+        Returns:
+            Dict: The JSON response from the server, or None if an error occurred.
+        """
+        url = self.url + endpoint
+        try:
+            logging.debug(
+                f"PUT URL: {url}, headers: {self.header}, params: {params}, json: {json_content}"
+            )
+            r = requests.put(
+                url,
+                headers=self.header,
+                json=json_content,
+                params=params,
+                verify=self.verify,
+            )
+            r.raise_for_status()
+        except requests.exceptions.HTTPError as err:
+            if r is not None:
+                logging.error(f"PUT error response: {r.text}")
+            logging.error(err)
+            return None
+        return r.json()
+
+    @network_exception_handling
+    def http_get_anonymous(
+        self,
+        endpoint: str = "",
+        url: Optional[str] = None,
+        params: Dict = {},
+    ) -> requests.Response:
+        """
+        Execute an HTTP GET without sending session credentials.
+
+        Useful for probes that must verify the API behavior for unauthenticated
+        callers — e.g. confirming a permission restriction prevents anonymous
+        reads. No Authorization header, no session cookie. Returns the raw
+        `requests.Response` so callers can inspect status code, headers, and
+        body; HTTP error statuses are NOT raised because they are frequently
+        the expected outcome.
+
+        Args:
+            endpoint (str): Endpoint relative to the configured API base URL.
+                Ignored when `url` is provided.
+            url (Optional[str]): Absolute URL to GET. Takes precedence over
+                `endpoint`.
+            params (Dict): Query-string parameters.
+
+        Returns:
+            requests.Response: The raw response.
+        """
+        target_url = url if url else self.url + endpoint
+        logging.debug(f"GET (anonymous) URL: {target_url}, params: {params}")
+        return requests.get(target_url, params=params, verify=self.verify)
+
+    @network_exception_handling
     def http_patch(
         self, endpoint: str, json_content: Dict = {}, params: Dict = {}, **kwargs
     ) -> Optional[Dict]:

--- a/src/geonoderest/userinfo.py
+++ b/src/geonoderest/userinfo.py
@@ -1,0 +1,18 @@
+from typing import Dict, Optional
+
+from geonoderest.rest import GeonodeRest
+
+
+class GeonodeUserInfoHandler(GeonodeRest):
+    """GET /api/v2/userinfo — identity claims for the authenticated user.
+
+    On GeoNode deployments that grant a session token, the response also
+    includes an `access_token` usable to authenticate downstream services
+    such as the bundled GeoServer.
+    """
+
+    ENDPOINT_NAME = "userinfo"
+
+    def get(self, **kwargs) -> Optional[Dict]:
+        """Return the userinfo claims dict, or None on error."""
+        return self.http_get(endpoint=f"{self.ENDPOINT_NAME}/")

--- a/src/geonoderest/wms.py
+++ b/src/geonoderest/wms.py
@@ -1,0 +1,82 @@
+from typing import Optional, Tuple
+import logging
+
+import requests
+
+from geonoderest.rest import GeonodeRest
+
+
+class GeonodeWmsHandler(GeonodeRest):
+    """WMS GetMap proxied through the GeoNode-managed GeoServer.
+
+    GeoServer is exposed at ``<geonode-base>/geoserver/ows`` (where
+    ``<geonode-base>`` is the GeoNode URL without the ``/api/v2/`` suffix).
+
+    GeoServer maintains its own user realm separate from Django's, so Basic
+    Auth headers intended for the Django REST API are rejected by GeoServer.
+    Authentication is performed via an OAuth2 ``access_token`` query
+    parameter — the same token returned by ``/api/v2/userinfo``. This
+    handler therefore issues anonymous HTTP and relies on the token in the
+    URL for credentials.
+    """
+
+    def get_map(
+        self,
+        layer: str,
+        bbox: Tuple[float, float, float, float],
+        width: int = 512,
+        height: int = 512,
+        srs: str = "EPSG:3857",
+        image_format: str = "image/png",
+        styles: Optional[str] = None,
+        transparent: bool = True,
+        tiled: bool = True,
+        access_token: Optional[str] = None,
+        version: str = "1.3.0",
+    ) -> requests.Response:
+        """Issue a WMS GetMap request and return the raw response.
+
+        Args:
+            layer (str): Layer name (typically the ``alternate`` of a dataset).
+            bbox (Tuple[float, float, float, float]): Bounding box in the
+                requested SRS, ``(minx, miny, maxx, maxy)``.
+            width (int): Image width in pixels. Defaults to 512.
+            height (int): Image height in pixels. Defaults to 512.
+            srs (str): Spatial reference system. Defaults to ``EPSG:3857``.
+            image_format (str): MIME type. Defaults to ``image/png``.
+            styles (Optional[str]): Style name. Defaults to the layer name
+                (matching GeoNode's default-style convention).
+            transparent (bool): Render with a transparent background.
+                Defaults to True.
+            tiled (bool): Pass through the GeoServer tiling hint.
+                Defaults to True.
+            access_token (Optional[str]): OAuth2 token granting GeoServer
+                access. If omitted, the request is anonymous.
+            version (str): WMS protocol version. Defaults to ``1.3.0``.
+
+        Returns:
+            requests.Response: The raw response. Image bytes are in
+            ``response.content``; check ``response.ok`` and
+            ``response.headers["Content-Type"]`` before consuming.
+        """
+        params = [
+            ("SERVICE", "WMS"),
+            ("VERSION", version),
+            ("REQUEST", "GetMap"),
+            ("FORMAT", image_format),
+            ("TRANSPARENT", str(transparent).lower()),
+            ("LAYERS", layer),
+            ("STYLES", styles if styles is not None else layer),
+            ("SRS", srs),
+            ("CRS", srs),
+            ("WIDTH", str(width)),
+            ("HEIGHT", str(height)),
+            ("BBOX", ",".join(str(c) for c in bbox)),
+            ("TILED", str(tiled).lower()),
+        ]
+        if access_token:
+            params.append(("access_token", access_token))
+
+        url = f"{self.gn_credentials.get_geonode_base_url()}/geoserver/ows"
+        logging.debug(f"WMS GET URL: {url}, params: {params}")
+        return requests.get(url, params=params, verify=self.verify)


### PR DESCRIPTION
Adds the following features:

- GeonodeUserInfoHandler.get() — wraps /api/v2/userinfo, exposes the identity claims plus the session access_token used downstream by GeoServer.
- GeonodePermissionsHandler.{get,set,wait_for_completion} — wraps the GET/PUT /api/v2/resources/{pk}/permissions endpoints. PUT is asynchronous (returns execution_id + status_url); callers can poll the execution to completion before relying on the new permission state.
- GeonodeWmsHandler.get_map() — issues WMS GetMap against the GeoNode-managed GeoServer. Sends no auth header because GeoServer's user realm rejects the Django Basic Auth credentials; the OAuth2 access_token query parameter (from /userinfo) is the credential.
- GeonodeExecutionRequestHandler.wait_for_completion(exec_id) — public polling primitive shared by uploads, async deletes, and permission changes. Raises GeoNodeRestException on `failed` or timeout.
- GeonodeResourceHandler.delete_async(pk) + wait_for_completion — the async sibling of the existing synchronous delete; returns the {status, execution_id, status_url} receipt so callers can confirm removal before downstream assertions.
- GeonodeRest.http_put() — fills the missing verb so PUT-style endpoints (permissions, future settings) can be hit without a custom requests call.
- GeonodeRest.http_get_anonymous() — issues a GET with no session credentials, returning the raw Response so callers can inspect 401/403 outcomes that are the expected result of a probe.

Also refactors the existing private GeonodeDatasetsHandler.__wait_for_upload__ to delegate to the new public wait_for_completion, removing the duplicated polling loop.

## Description

A brief description of the feature or bug that this pull request addresses.

## Type of Change

Please select the relevant option:

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [x] Refactoring
- [ ] Release
- [ ] Other (please describe)

## Related Issue

If there is an existing issue related to this pull request, please reference it here.

closes #

## Checklist

Please ensure that your pull request meets the following requirements:

- The pull request is limited to one type (docs, feature, bug fix, etc.)
- The pull request is as small as possible. Consider opening multiple pull requests instead of one large one.
- The feature or bug fix has been discussed and documented in an issue beforehand.

## Additional Notes

Any additional information or context regarding the pull request can be provided here.

Thank you for creating this pull request