### PR TITLE
Add users transfer_resources to hand resources to another user

### DIFF
--- a/docs/example.md
+++ b/docs/example.md
@@ -47,7 +47,7 @@ Currently not all features of the API are implemented. Here is a list of what yo
 | documents        | list, delete, patch, describe, upload |
 | maps             | list, delete, patch, describe, create |
 | geoapps          | list, delete, patch, describe |
-| users            | list, delete, patch, describe, create |
+| users            | list, delete, patch, describe, create, transfer_resources |
 | uploads          | list, describe |
 | executionrequest | list, describe |
 | keywords         | list, describe |

--- a/src/geonoderest/geonodectl.py
+++ b/src/geonoderest/geonodectl.py
@@ -860,6 +860,29 @@ To use this tool you have to set the following environment variables before star
         "is_staff": true, "is_superuser": true}\' ... (mutually exclusive [c])',
     )
 
+    # TRANSFER RESOURCES
+    users_transfer_resources = users_subparsers.add_parser(
+        "transfer_resources", help="hand resources of a user over to another user"
+    )
+    users_transfer_resources.add_argument(
+        type=int, dest="pk", help="pk of the user currently owning the resources"
+    )
+    users_transfer_resources.add_argument(
+        "--new_owner",
+        type=int,
+        dest="new_owner",
+        required=True,
+        help="pk of the user to hand the resources to ...",
+    )
+    users_transfer_resources.add_argument(
+        "--resources",
+        nargs="+",
+        type=int,
+        dest="resources",
+        help="pks of the resources to move, like --resources 1 2 3. Moves every resource \
+        of the user if left out. Needs GeoNode 5, GeoNode 4.4 can only move all of them ...",
+    )
+
     ###########################
     # GROUPS ARGUMENT PARSING #
     ###########################

--- a/src/geonoderest/users.py
+++ b/src/geonoderest/users.py
@@ -1,11 +1,12 @@
 import json
 import sys
 import logging
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from geonoderest.resources import GeonodeResourceHandler
 from geonoderest.geonodeobject import GeonodeObjectHandler
 from geonoderest.geonodetypes import GeonodeCmdOutListKey
+from geonoderest.exceptions import GeoNodeRestException
 from geonoderest.cmdprint import (
     print_list_on_cmd,
     print_json,
@@ -259,3 +260,76 @@ class GeonodeUsersHandler(GeonodeObjectHandler):
         """delete geonode resource object"""
         self.http_get(endpoint=f"{self.ENDPOINT_NAME}/{pk}")
         self.http_delete(endpoint=f"users/{pk}")
+
+    def cmd_transfer_resources(
+        self,
+        pk: int,
+        new_owner: int,
+        resources: Optional[List[int]] = None,
+        **kwargs,
+    ):
+        """hand resources of a user over to another user and print the result
+
+        Args:
+            pk (int): id of the user currently owning the resources
+            new_owner (int): id of the user to hand them to
+            resources (Optional[List[int]]): ids of the resources to move,
+                                             all of the users resources if left out
+        """
+        print_json(
+            self.transfer_resources(
+                pk=pk, new_owner=new_owner, resources=resources, **kwargs
+            )
+        )
+
+    def transfer_resources(
+        self,
+        pk: int,
+        new_owner: int,
+        resources: Optional[List[int]] = None,
+        **kwargs,
+    ) -> Optional[Dict]:
+        """hand resources of a user over to another user
+
+        Two shapes of this endpoint are in the wild. GeoNode 5 takes newOwner,
+        currentOwner and an optional list of resource ids; GeoNode 4.4 takes a
+        single `owner` and always moves every resource the user owns. The
+        modern payload is sent first and the legacy one only after GeoNode has
+        answered that it did not understand it.
+
+        Note that `resources` is always sent, empty for a whole-account
+        transfer: GeoNode 5 raises a TypeError on a JSON body that leaves it
+        out entirely.
+
+        Args:
+            pk (int): id of the user currently owning the resources
+            new_owner (int): id of the user to hand them to
+            resources (Optional[List[int]]): ids of the resources to move,
+                                             all of the users resources if left out
+
+        Raises:
+            GeoNodeRestException: if a subset was asked for but the GeoNode
+                                  only offers the whole-account transfer
+
+        Returns:
+            Optional[Dict]: the API response, or None if the transfer failed
+        """
+        endpoint = f"{self.ENDPOINT_NAME}/{pk}/transfer_resources"
+        obj = self.http_post(
+            endpoint=endpoint,
+            json={
+                "newOwner": new_owner,
+                "currentOwner": pk,
+                "resources": resources or [],
+            },
+        )
+        if obj is not None:
+            return obj
+
+        if resources:
+            raise GeoNodeRestException(
+                "could not transfer the given resources. On GeoNode 4.4 this endpoint moves "
+                "every resource of the user and cannot be given a subset ..."
+            )
+        logging.info("retrying with the GeoNode 4.4 payload ...")
+        return self.http_post(endpoint=endpoint, json={"owner": new_owner})

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,0 +1,58 @@
+import unittest
+from unittest.mock import patch
+
+from geonoderest.users import GeonodeUsersHandler
+from geonoderest.exceptions import GeoNodeRestException
+
+
+class TestGeonodeUsersHandlerTransferResources(unittest.TestCase):
+
+    @patch.object(GeonodeUsersHandler, "http_post")
+    def test_transfer_resources_subset(self, mock_http_post):
+        """Ensure the modern payload carries the subset and no retry happens."""
+        mock_http_post.return_value = "Resources transfered successfully"
+        handler = GeonodeUsersHandler(env={})
+        result = handler.transfer_resources(pk=3, new_owner=7, resources=[11, 12])
+        mock_http_post.assert_called_once_with(
+            endpoint="users/3/transfer_resources",
+            json={"newOwner": 7, "currentOwner": 3, "resources": [11, 12]},
+        )
+        self.assertEqual(result, "Resources transfered successfully")
+
+    @patch.object(GeonodeUsersHandler, "http_post")
+    def test_transfer_all_resources_sends_an_empty_subset(self, mock_http_post):
+        """GeoNode 5 raises a TypeError if `resources` is missing from a JSON body."""
+        mock_http_post.return_value = "Resources transfered successfully"
+        handler = GeonodeUsersHandler(env={})
+        handler.transfer_resources(pk=3, new_owner=7)
+        self.assertEqual(mock_http_post.call_args.kwargs["json"]["resources"], [])
+
+    @patch.object(GeonodeUsersHandler, "http_post")
+    def test_transfer_all_resources_falls_back_to_the_geonode_44_payload(
+        self, mock_http_post
+    ):
+        """GeoNode 4.4 does not know newOwner, so the legacy `owner` is tried after it."""
+        mock_http_post.side_effect = [None, "Resources transfered successfully"]
+        handler = GeonodeUsersHandler(env={})
+        result = handler.transfer_resources(pk=3, new_owner=7)
+        self.assertEqual(mock_http_post.call_count, 2)
+        self.assertEqual(
+            mock_http_post.call_args.kwargs,
+            {"endpoint": "users/3/transfer_resources", "json": {"owner": 7}},
+        )
+        self.assertEqual(result, "Resources transfered successfully")
+
+    @patch.object(GeonodeUsersHandler, "http_post")
+    def test_transfer_of_a_subset_is_not_retried_as_a_whole_account_transfer(
+        self, mock_http_post
+    ):
+        """The GeoNode 4.4 payload would move every resource, which was not asked for."""
+        mock_http_post.return_value = None
+        handler = GeonodeUsersHandler(env={})
+        with self.assertRaises(GeoNodeRestException):
+            handler.transfer_resources(pk=3, new_owner=7, resources=[11])
+        mock_http_post.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds the one thing that was missing to move a resource to a different owner from the command line:

```
geonodectl users transfer_resources 3 --new_owner 7
geonodectl users transfer_resources 3 --new_owner 7 --resources 11 12
```

`POST /api/v2/users/{pk}/transfer_resources` exists in two shapes. GeoNode 5 takes `newOwner`, `currentOwner` and an optional list of resource ids; GeoNode 4.4 takes a single `owner` and always moves every resource the user owns. The modern payload goes out first, and the legacy one is only tried after GeoNode answers that it did not understand it. A subset is never retried that way - the 4.4 endpoint would move everything rather than the resources that were asked for, so that case raises instead.

`resources` is always sent, empty for a whole-account transfer. GeoNode 5 raises a `TypeError` on a JSON body that leaves the key out entirely (GeoNode/geonode#14473), and an empty list walks around it.

Four unit tests in `tests/test_users.py`, mocking `http_post` in the same style as the existing handler tests. `unittest discover` is green (48 tests), `black` and `flake8` clean, `mypy -p src.geonoderest --check-untyped-defs --disable-error-code=import-untyped` reports only the pre-existing `raise NotImplemented` in `geonodectl.py`.

Not tested against a live GeoNode yet - review welcome on whether the version fallback is the shape you want, or whether you would rather gate it on a configured API version.
